### PR TITLE
Implement integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,4 +64,25 @@ jobs:
                 run: composer update --ansi --no-progress --prefer-dist --no-interaction ${{ matrix.composer_flags }}
 
             -   name: Run tests
-                run: vendor/bin/phpunit --colors=always
+                run: vendor/bin/phpunit --colors=always --exclude-group=integration
+
+    integration_tests:
+        name: "Integration tests"
+        runs-on: ubuntu-latest
+
+        steps:
+            -   uses: actions/checkout@v3
+            -   uses: shivammathur/setup-php@v2
+                with:
+                    coverage: "none"
+                    php-version: "8.2"
+
+            -   name: Install dependencies
+                run: composer update --ansi --no-progress --prefer-dist --no-interaction
+
+            -   name: Run tests
+                run: vendor/bin/phpunit --colors=always --group=integration --display-skipped
+                env:
+                    AMAZON_INCENTIVES_ACCESS_KEY: ${{ secrets.AMAZON_INCENTIVES_ACCESS_KEY }}
+                    AMAZON_INCENTIVES_PARTNER_ID: ${{ secrets.AMAZON_INCENTIVES_PARTNER_ID }}
+                    AMAZON_INCENTIVES_SECRET_KEY: ${{ secrets.AMAZON_INCENTIVES_SECRET_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 /composer.lock
+/phpunit.xml
 *.cache

--- a/tests/Integration/AmazonIncentivesClientTest.php
+++ b/tests/Integration/AmazonIncentivesClientTest.php
@@ -2,17 +2,21 @@
 
 namespace Incenteev\AsyncAmazonIncentives\Tests\Integration;
 
-use AsyncAws\Core\Credentials\NullProvider;
+use AsyncAws\Core\Credentials\Credentials;
 use AsyncAws\Core\Test\TestCase;
 use Incenteev\AsyncAmazonIncentives\AmazonIncentivesClient;
 use Incenteev\AsyncAmazonIncentives\Enum\CurrencyCode;
 use Incenteev\AsyncAmazonIncentives\Enum\Status;
+use Incenteev\AsyncAmazonIncentives\Exception\InsufficientFundsException;
+use Incenteev\AsyncAmazonIncentives\Exception\ThrottlingException;
 use Incenteev\AsyncAmazonIncentives\Input\CancelGiftCardRequest;
 use Incenteev\AsyncAmazonIncentives\Input\CreateGiftCardRequest;
 use Incenteev\AsyncAmazonIncentives\Input\GetAvailableFundsRequest;
 use Incenteev\AsyncAmazonIncentives\Region;
 use Incenteev\AsyncAmazonIncentives\ValueObject\MoneyAmount;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('integration')]
 class AmazonIncentivesClientTest extends TestCase
 {
     public function testCancelGiftCard(): void
@@ -20,16 +24,21 @@ class AmazonIncentivesClientTest extends TestCase
         $client = $this->getClient();
 
         $input = new CancelGiftCardRequest([
-            'creationRequestId' => 'change me',
-            'partnerId' => 'change me',
-            'gcId' => 'change me',
+            'creationRequestId' => 'F0000',
+            'partnerId' => $this->getPartnerId(),
+            'gcId' => 'AMAZONGCID',
         ]);
-        $result = $client->cancelGiftCard($input);
 
-        $result->resolve();
+        try {
+            $result = $client->cancelGiftCard($input);
 
-        self::assertSame('changeIt', $result->getCreationRequestId());
-        self::assertSame('changeIt', $result->getStatus());
+            $result->resolve();
+        } catch (ThrottlingException $e) {
+            self::markTestSkipped('Could not run the integration tests: ' . $e->getMessage());
+        }
+
+        self::assertSame('F0000', $result->getCreationRequestId());
+        self::assertSame(Status::SUCCESS, $result->getStatus());
     }
 
     public function testCreateGiftCard(): void
@@ -37,20 +46,51 @@ class AmazonIncentivesClientTest extends TestCase
         $client = $this->getClient();
 
         $input = new CreateGiftCardRequest([
-            'creationRequestId' => 'change me',
-            'partnerId' => 'change me',
+            'creationRequestId' => 'F0000',
+            'partnerId' => $this->getPartnerId(),
             'value' => new MoneyAmount([
                 'amount' => 10,
                 'currencyCode' => CurrencyCode::EUR,
             ]),
         ]);
-        $result = $client->createGiftCard($input);
 
-        $result->resolve();
+        try {
+            $result = $client->createGiftCard($input);
+
+            $result->resolve();
+        } catch (ThrottlingException $e) {
+            self::markTestSkipped('Could not run the integration tests: ' . $e->getMessage());
+        }
 
         self::assertSame(10.0, $result->getCardInfo()->getValue()->getAmount());
-        self::assertSame('changeIt', $result->getCreationRequestId());
+        self::assertSame('F0000', $result->getCreationRequestId());
         self::assertSame(Status::SUCCESS, $result->getStatus());
+        self::assertNotEmpty($result->getGcClaimCode());
+        self::assertNotEmpty($result->getGcId());
+    }
+
+    public function testCreateGiftCardFailure(): void
+    {
+        $client = $this->getClient();
+
+        $input = new CreateGiftCardRequest([
+            'creationRequestId' => 'F3003',
+            'partnerId' => $this->getPartnerId(),
+            'value' => new MoneyAmount([
+                'amount' => 10,
+                'currencyCode' => CurrencyCode::EUR,
+            ]),
+        ]);
+
+        $this->expectException(InsufficientFundsException::class);
+
+        try {
+            $result = $client->createGiftCard($input);
+
+            $result->resolve();
+        } catch (ThrottlingException $e) {
+            self::markTestSkipped('Could not run the integration tests: ' . $e->getMessage());
+        }
     }
 
     public function testGetAvailableFunds(): void
@@ -58,24 +98,38 @@ class AmazonIncentivesClientTest extends TestCase
         $client = $this->getClient();
 
         $input = new GetAvailableFundsRequest([
-            'partnerId' => 'change me',
+            'partnerId' => $this->getPartnerId(),
         ]);
-        $result = $client->getAvailableFunds($input);
 
-        $result->resolve();
+        try {
+            $result = $client->getAvailableFunds($input);
 
-        // self::assertTODO(expected, $result->getAvailableFunds());
-        self::assertSame('changeIt', $result->getStatus());
-        // self::assertTODO(expected, $result->getTimestamp());
+            $result->resolve();
+        } catch (ThrottlingException $e) {
+            self::markTestSkipped('Could not run the integration tests: ' . $e->getMessage());
+        }
+
+        self::assertSame(0.0, $result->getAvailableFunds()->getAmount()); // the balance is always 0 for a sandbox
+        self::assertSame(Status::SUCCESS, $result->getStatus());
     }
 
     private function getClient(): AmazonIncentivesClient
     {
-        self::markTestIncomplete('Not implemented');
+        if (!isset($_SERVER['AMAZON_INCENTIVES_ACCESS_KEY'], $_SERVER['AMAZON_INCENTIVES_SECRET_KEY']) || $_SERVER['AMAZON_INCENTIVES_ACCESS_KEY'] === '' || $_SERVER['AMAZON_INCENTIVES_SECRET_KEY'] === '') {
+            self::markTestSkipped('Test credentials are not provided.');
+        }
 
-        // @phpstan-ignore-next-line
         return new AmazonIncentivesClient([
             'region' => Region::EUROPE_AND_ASIA_SANDBOX,
-        ], new NullProvider());
+        ], new Credentials($_SERVER['AMAZON_INCENTIVES_ACCESS_KEY'], $_SERVER['AMAZON_INCENTIVES_SECRET_KEY']));
+    }
+
+    private function getPartnerId(): string
+    {
+        if (!isset($_SERVER['AMAZON_INCENTIVES_PARTNER_ID']) || $_SERVER['AMAZON_INCENTIVES_PARTNER_ID'] === '') {
+            self::markTestSkipped('Test credentials are not provided.');
+        }
+
+        return $_SERVER['AMAZON_INCENTIVES_PARTNER_ID'];
     }
 }


### PR DESCRIPTION
The CI runs them as a dedicated job on a single PHP version because the Amazon Incentives sandbox endpoint are still subject to rate limiting. Tests are marked as skipped if the rate limit is reached.