### PR TITLE
Improve the php-cs-fixer configuration

### DIFF
--- a/.cache/generate/.gitignore
+++ b/.cache/generate/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/.cache/php-cs-fixer/.gitignore
+++ b/.cache/php-cs-fixer/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,19 @@ jobs:
               run: composer update --ansi --no-progress --prefer-dist --no-interaction
             - run: vendor/bin/phpstan analyze
 
+    coding_standards:
+        name: Coding standards
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - uses: shivammathur/setup-php@v2
+              with:
+                  coverage: none
+                  php-version: '8.1'
+            - name: Install dependencies
+              run: composer update --ansi --no-progress --prefer-dist --no-interaction
+            - run: vendor/bin/php-cs-fixer fix --dry-run --show-progress=dots --no-interaction
+
     tests:
         name: "Tests on PHP ${{ matrix.php }}${{ matrix.name_suffix }}"
         runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /vendor/
 /composer.lock
 /phpunit.xml
-*.cache
+/.phpunit.result.cache

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -83,6 +83,7 @@ return (new PhpCsFixer\Config())
         'ordered_class_elements' => ['sort_algorithm' => 'none'],
         'class_attributes_separation' => ['elements' => ['property' => 'one', 'method' => 'one']],
         'array_indentation' => true,
+        'ternary_to_null_coalescing' => true,
     ])
     ->setFinder($finder)
 ;

--- a/src/ValueObject/CardInfo.php
+++ b/src/ValueObject/CardInfo.php
@@ -25,7 +25,7 @@ final class CardInfo
     public function __construct(array $input)
     {
         $this->value = isset($input['value']) ? MoneyAmount::create($input['value']) : $this->throwException(new InvalidArgument('Missing required field "value".'));
-        $this->cardStatus = isset($input['cardStatus']) ? $input['cardStatus'] : $this->throwException(new InvalidArgument('Missing required field "cardStatus".'));
+        $this->cardStatus = $input['cardStatus'] ?? $this->throwException(new InvalidArgument('Missing required field "cardStatus".'));
     }
 
     /**

--- a/src/ValueObject/MoneyAmount.php
+++ b/src/ValueObject/MoneyAmount.php
@@ -25,8 +25,8 @@ final class MoneyAmount
      */
     public function __construct(array $input)
     {
-        $this->amount = isset($input['amount']) ? $input['amount'] : $this->throwException(new InvalidArgument('Missing required field "amount".'));
-        $this->currencyCode = isset($input['currencyCode']) ? $input['currencyCode'] : $this->throwException(new InvalidArgument('Missing required field "currencyCode".'));
+        $this->amount = $input['amount'] ?? $this->throwException(new InvalidArgument('Missing required field "amount".'));
+        $this->currencyCode = $input['currencyCode'] ?? $this->throwException(new InvalidArgument('Missing required field "currencyCode".'));
     }
 
     /**

--- a/tests/Integration/AmazonIncentivesClientTest.php
+++ b/tests/Integration/AmazonIncentivesClientTest.php
@@ -115,7 +115,7 @@ class AmazonIncentivesClientTest extends TestCase
 
     private function getClient(): AmazonIncentivesClient
     {
-        if (!isset($_SERVER['AMAZON_INCENTIVES_ACCESS_KEY'], $_SERVER['AMAZON_INCENTIVES_SECRET_KEY']) || $_SERVER['AMAZON_INCENTIVES_ACCESS_KEY'] === '' || $_SERVER['AMAZON_INCENTIVES_SECRET_KEY'] === '') {
+        if (!isset($_SERVER['AMAZON_INCENTIVES_ACCESS_KEY'], $_SERVER['AMAZON_INCENTIVES_SECRET_KEY']) || '' === $_SERVER['AMAZON_INCENTIVES_ACCESS_KEY'] || '' === $_SERVER['AMAZON_INCENTIVES_SECRET_KEY']) {
             self::markTestSkipped('Test credentials are not provided.');
         }
 
@@ -126,7 +126,7 @@ class AmazonIncentivesClientTest extends TestCase
 
     private function getPartnerId(): string
     {
-        if (!isset($_SERVER['AMAZON_INCENTIVES_PARTNER_ID']) || $_SERVER['AMAZON_INCENTIVES_PARTNER_ID'] === '') {
+        if (!isset($_SERVER['AMAZON_INCENTIVES_PARTNER_ID']) || '' === $_SERVER['AMAZON_INCENTIVES_PARTNER_ID']) {
             self::markTestSkipped('Test credentials are not provided.');
         }
 


### PR DESCRIPTION
Enabling `ternary_to_null_coalescing` matches the configuration used in async-aws now.