### PR TITLE
fixed signRegion setting for far east endpoints

### DIFF
--- a/manifest/endpoints.json
+++ b/manifest/endpoints.json
@@ -56,13 +56,13 @@
           "fe": {
             "hostname": "agcod-v2-fe.amazon.com",
             "credentialScope": {
-              "region": "eu-west-1"
+              "region": "us-west-2"
             }
           },
           "fe-sandbox": {
             "hostname": "agcod-v2-fe-gamma.amazon.com",
             "credentialScope": {
-              "region": "eu-west-1"
+              "region": "us-west-2"
             }
           }
         }

--- a/src/AmazonIncentivesClient.php
+++ b/src/AmazonIncentivesClient.php
@@ -375,14 +375,14 @@ class AmazonIncentivesClient extends AbstractApi
             case 'fe':
                 return [
                     'endpoint' => 'https://agcod-v2-fe.amazon.com',
-                    'signRegion' => 'eu-west-1',
+                    'signRegion' => 'us-west-2',
                     'signService' => 'AGCODService',
                     'signVersions' => ['v4'],
                 ];
             case 'fe-sandbox':
                 return [
                     'endpoint' => 'https://agcod-v2-fe-gamma.amazon.com',
-                    'signRegion' => 'eu-west-1',
+                    'signRegion' => 'us-west-2',
                     'signService' => 'AGCODService',
                     'signVersions' => ['v4'],
                 ];
@@ -402,6 +402,6 @@ class AmazonIncentivesClient extends AbstractApi
                 ];
         }
 
-        throw new UnsupportedRegion(sprintf('The region "%s" is not supported by "AmazonIncentives".', $region));
+        throw new UnsupportedRegion(\sprintf('The region "%s" is not supported by "AmazonIncentives".', $region));
     }
 }


### PR DESCRIPTION
Hi, signRegion for far east region is `us-west-2` not `eu-west-1`. 
https://developer.amazon.com/docs/incentives-api/incentives-api.html#endpoints

We need valid signRegion for far east endpoint.
Thanks in advance.