### PR TITLE
Fix coding standards

### DIFF
--- a/src/AmazonIncentivesClient.php
+++ b/src/AmazonIncentivesClient.php
@@ -402,6 +402,6 @@ class AmazonIncentivesClient extends AbstractApi
                 ];
         }
 
-        throw new UnsupportedRegion(sprintf('The region "%s" is not supported by "AmazonIncentives".', $region));
+        throw new UnsupportedRegion(\sprintf('The region "%s" is not supported by "AmazonIncentives".', $region));
     }
 }

--- a/src/Input/CancelGiftCardRequest.php
+++ b/src/Input/CancelGiftCardRequest.php
@@ -125,15 +125,15 @@ final class CancelGiftCardRequest extends Input
     private function requestBody(\DOMNode $node, \DOMDocument $document): void
     {
         if (null === $v = $this->creationRequestId) {
-            throw new InvalidArgument(sprintf('Missing parameter "creationRequestId" for "%s". The value cannot be null.', __CLASS__));
+            throw new InvalidArgument(\sprintf('Missing parameter "creationRequestId" for "%s". The value cannot be null.', __CLASS__));
         }
         $node->appendChild($document->createElement('creationRequestId', $v));
         if (null === $v = $this->partnerId) {
-            throw new InvalidArgument(sprintf('Missing parameter "partnerId" for "%s". The value cannot be null.', __CLASS__));
+            throw new InvalidArgument(\sprintf('Missing parameter "partnerId" for "%s". The value cannot be null.', __CLASS__));
         }
         $node->appendChild($document->createElement('partnerId', $v));
         if (null === $v = $this->gcId) {
-            throw new InvalidArgument(sprintf('Missing parameter "gcId" for "%s". The value cannot be null.', __CLASS__));
+            throw new InvalidArgument(\sprintf('Missing parameter "gcId" for "%s". The value cannot be null.', __CLASS__));
         }
         $node->appendChild($document->createElement('gcId', $v));
     }

--- a/src/Input/CreateGiftCardRequest.php
+++ b/src/Input/CreateGiftCardRequest.php
@@ -174,15 +174,15 @@ final class CreateGiftCardRequest extends Input
     private function requestBody(\DOMNode $node, \DOMDocument $document): void
     {
         if (null === $v = $this->creationRequestId) {
-            throw new InvalidArgument(sprintf('Missing parameter "creationRequestId" for "%s". The value cannot be null.', __CLASS__));
+            throw new InvalidArgument(\sprintf('Missing parameter "creationRequestId" for "%s". The value cannot be null.', __CLASS__));
         }
         $node->appendChild($document->createElement('creationRequestId', $v));
         if (null === $v = $this->partnerId) {
-            throw new InvalidArgument(sprintf('Missing parameter "partnerId" for "%s". The value cannot be null.', __CLASS__));
+            throw new InvalidArgument(\sprintf('Missing parameter "partnerId" for "%s". The value cannot be null.', __CLASS__));
         }
         $node->appendChild($document->createElement('partnerId', $v));
         if (null === $v = $this->value) {
-            throw new InvalidArgument(sprintf('Missing parameter "value" for "%s". The value cannot be null.', __CLASS__));
+            throw new InvalidArgument(\sprintf('Missing parameter "value" for "%s". The value cannot be null.', __CLASS__));
         }
 
         $node->appendChild($child = $document->createElement('value'));

--- a/src/Input/GetAvailableFundsRequest.php
+++ b/src/Input/GetAvailableFundsRequest.php
@@ -81,7 +81,7 @@ final class GetAvailableFundsRequest extends Input
     private function requestBody(\DOMNode $node, \DOMDocument $document): void
     {
         if (null === $v = $this->partnerId) {
-            throw new InvalidArgument(sprintf('Missing parameter "partnerId" for "%s". The value cannot be null.', __CLASS__));
+            throw new InvalidArgument(\sprintf('Missing parameter "partnerId" for "%s". The value cannot be null.', __CLASS__));
         }
         $node->appendChild($document->createElement('partnerId', $v));
     }

--- a/src/ValueObject/MoneyAmount.php
+++ b/src/ValueObject/MoneyAmount.php
@@ -62,7 +62,7 @@ final class MoneyAmount
         $node->appendChild($document->createElement('amount', (string) $v));
         $v = $this->currencyCode;
         if (!CurrencyCode::exists($v)) {
-            throw new InvalidArgument(sprintf('Invalid parameter "currencyCode" for "%s". The value "%s" is not a valid "CurrencyCode".', __CLASS__, $v));
+            throw new InvalidArgument(\sprintf('Invalid parameter "currencyCode" for "%s". The value "%s" is not a valid "CurrencyCode".', __CLASS__, $v));
         }
         $node->appendChild($document->createElement('currencyCode', $v));
     }


### PR DESCRIPTION
The new version of php-cs-fixer requires qualifying calls to `sprintf` to benefit from the PHP 8.4 optimization.